### PR TITLE
Added the template for git commit msg

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,11 @@
+<type>(<milestone#>[.<scope>]): <short summary ≤50 chars>
+
+<Explain the ‘why’ and the ‘what’ in context of the milestone>
+- Reference milestone goal (e.g., db setup, API container)
+- Talk about expectations satisfied (e.g., migrations auto-run)
+
+BREAKING CHANGE: <describe if updates or environment have changed>
+
+Footer:
+- Milestone #<number>
+- Closes #<issue-number> (optional)


### PR DESCRIPTION
feat(milestone2.git): Added the template for commit msg
Going to follow the a templated commit msg - It helps in semversioning and ci/cd tagging

BREAKING CHANGE: None

Footer:
- Milestone 2
- Closes None