### PR TITLE
fix(milestone3.readme): Fix the typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ make docker build & run # Build the docker image and runs the restapi webserver.
 System where make tooll cannot be installed use the python task.py file do all the build, run and all 
 
 ### Notes
-    1. You can direclty start , migrate, run  using mak commands
+    1. You can direclty start , migrate, run  using make commands
 
 ## 🧬 OpenAPI Schema
 


### PR DESCRIPTION
There was type in the notes of using make commands.
- Fixt type from mak to make

BREAKING CHANGE: None

Footer:
- Milestone 3
- Closes None